### PR TITLE
indexer: change analyzer and payload

### DIFF
--- a/invenio_openaire/indexer.py
+++ b/invenio_openaire/indexer.py
@@ -45,7 +45,9 @@ def indexer_receiver(sender, json=None, record=None, index=None,
                 'funder': [json['funder']['doi']]
             },
             'payload': {
-                'id': json['internal_id']
+                'id': json['internal_id'],
+                'legacy_id': (json['code'] if json.get('program') == 'FP7'
+                              else json['internal_id'])
             },
         }
     elif index and index.startswith('funders-'):

--- a/invenio_openaire/mappings/funders/funder-v1.0.0.json
+++ b/invenio_openaire/mappings/funders/funder-v1.0.0.json
@@ -52,8 +52,8 @@
         },
         "suggest": {
           "type": "completion",
-          "analyzer" : "simple",
-          "search_analyzer" : "simple",
+          "analyzer" : "snowball",
+          "search_analyzer" : "snowball",
           "payloads" : true
         }
       }

--- a/invenio_openaire/mappings/grants/grant-v1.0.0.json
+++ b/invenio_openaire/mappings/grants/grant-v1.0.0.json
@@ -101,8 +101,8 @@
         },
         "suggest": {
           "type": "completion",
-          "analyzer" : "simple",
-          "search_analyzer" : "simple",
+          "analyzer" : "snowball",
+          "search_analyzer" : "snowball",
           "payloads" : true,
           "context": {
             "funder": {


### PR DESCRIPTION
- Uses the 'snowball' analyzer when indexing documents in order to
  also respond to number strings in search queries.
- Adds a `legacy_id` field to the grant's suggestion payload.

Signed-off-by: Alexander Ioannidis a.ioannidis@cern.ch
