### PR TITLE
docs: new maintainer

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,1 +1,2 @@
 Lars Holm Nielsen <lars.holm.nielsen@cern.ch> (@lnielsen)
+Krzysztof Nowak <k.nowak@cern.ch> (@krzysztof)


### PR DESCRIPTION
Signed-off-by: Krzysztof Nowak <k.nowak@cern.ch>